### PR TITLE
Fix `expressionCache` bug

### DIFF
--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -25,7 +25,7 @@ export const useMDXComponents = (): Record<string, (properties: ParentProps) => 
 const REPLACED_COMPAT_SET = new Set(['mjx']);
 const compatRegExp = new RegExp(`(?:${[...REPLACED_COMPAT_SET].join('|')})-.+`, 'g');
 
-const expressionCache: Record<string, string> = Object.create(null);
+const expressionCache = Object.create(null) as Record<string, string>;
 const replaceDashWithUnderscore = <T>(expression: T): string | T =>
   typeof expression === 'string'
     ? expressionCache[expression] ??

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -25,7 +25,7 @@ export const useMDXComponents = (): Record<string, (properties: ParentProps) => 
 const REPLACED_COMPAT_SET = new Set(['mjx']);
 const compatRegExp = new RegExp(`(?:${[...REPLACED_COMPAT_SET].join('|')})-.+`, 'g');
 
-const expressionCache: Record<string, string> = {};
+const expressionCache: Record<string, string> = Object.create(null);
 const replaceDashWithUnderscore = <T>(expression: T): string | T =>
   typeof expression === 'string'
     ? expressionCache[expression] ??

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -10,7 +10,7 @@ export const capitalizeFirstLetter = (
 
 const attributeCamelCasedRegExp =
   /e(r[HRWrv]|[Vawy])|Con|l(e[Tcs]|c)|s(eP|y)|a(t[rt]|u|v)|Of|Ex|f[XYa]|gt|hR|d[Pg]|t[TXYd]|[UZq]/; //URL: https://regex101.com/r/I8Wm4S/1
-const attributesCache: Record<string, string> = {};
+const attributesCache = Object.create(null) as Record<string, string>;
 const uppercaseRe = /[A-Z]/g;
 
 export const normalizeKeySvg = (key: string): string =>


### PR DESCRIPTION
`expressionCache` is a plain object which will give a property from object prototype if `expression` is one of them e.g `toString`, `constructor` causing all sorts of unexpected behavior such as one seen in https://github.com/solidjs/solid-docs/issues/175

example code that can fail
```
jsx('x', { children: 'constructor' })
jsx('x', { children: '__proto__' })
```

on a related note, this type of bug also affects `solid-js`